### PR TITLE
Stopped app from going into landscape view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:supportsRtl="true"
         android:theme="@style/PRO5Theme">
         <activity android:name=".MainActivity">
+            android:screenOrientation="portrait"
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Added the line android:screenOrientation="portrait" to stop the MainActivity from going into landscape view.